### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.0...v0.1.1) - 2024-12-29
+
+### Fixed
+
+- Fix behaviour when return String type
+
+### Other
+
+- *(example)* New example for structured output
+- Add documentation for examples, update simple example
+- Update documentation
+- Move AgentTool to separate module
+
 ## 0.1.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `agentai`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.0...v0.1.1) - 2024-12-29

### Fixed

- Fix behaviour when return String type

### Other

- *(example)* New example for structured output
- Add documentation for examples, update simple example
- Update documentation
- Move AgentTool to separate module
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).