### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.1...v0.1.2) - 2025-01-05
+
+### Other
+
+- Fix links in README
+- Update documentation (#7)
+- *(example)* Custom Tool Example (#6)
+- Implement Web Search Tool + add examples
+- update documentation for Agent structure
+- clippy updates
+- convert tabs into spaces
+
 ## [0.1.1](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.0...v0.1.1) - 2024-12-29
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `agentai`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.1...v0.1.2) - 2025-01-05

### Other

- Fix links in README
- Update documentation (#7)
- *(example)* Custom Tool Example (#6)
- Implement Web Search Tool + add examples
- update documentation for Agent structure
- clippy updates
- convert tabs into spaces
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).