### PR TITLE
Release agentai v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.2...v0.1.3) - 2025-01-14
+
+### Other
+
+- Chore/MCP Client tools and documentation ([#10](https://github.com/AdamStrojek/rust-agentai/pull/10))
+- Feature/MCP Support ([#9](https://github.com/AdamStrojek/rust-agentai/pull/9))
+- Chore/CI ([#8](https://github.com/AdamStrojek/rust-agentai/pull/8))
+
 ## [0.1.2](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.1...v0.1.2) - 2025-01-05
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `agentai`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.2...v0.1.3) - 2025-01-14

### Other

- Chore/MCP Client tools and documentation ([#10](https://github.com/AdamStrojek/rust-agentai/pull/10))
- Feature/MCP Support ([#9](https://github.com/AdamStrojek/rust-agentai/pull/9))
- Chore/CI ([#8](https://github.com/AdamStrojek/rust-agentai/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).