### PR TITLE
Release `agentai` v0.1.5

### DIFF
--- a/crates/agentai-macros/CHANGELOG.md
+++ b/crates/agentai-macros/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.5](https://github.com/AdamStrojek/rust-agentai/compare/agentai-macros-v0.1.0...agentai-macros-v0.1.5) - 2025-07-19
+
+### Miscellaneous
+- Update lib.rs (by @AdamStrojek) - #27
+- Move crates to separate folders (by @AdamStrojek) - #27
+
+### Contributors
+
+* @AdamStrojek

--- a/crates/agentai-macros/Cargo.toml
+++ b/crates/agentai-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai-macros"
-version = "0.1.0"
+version = "0.1.5"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"

--- a/crates/agentai/CHANGELOG.md
+++ b/crates/agentai/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.5](https://github.com/AdamStrojek/rust-agentai/compare/agentai-v0.1.4...agentai-v0.1.5) - 2025-07-19
+
+### New features
+- ToolBox ([#18](https://github.com/AdamStrojek/rust-agentai/pull/18)) (by @AdamStrojek) - #18
+
+### Miscellaneous
+- Move crates to separate folders (by @AdamStrojek) - #27
+
+### Contributors
+
+* @AdamStrojek

--- a/crates/agentai/Cargo.toml
+++ b/crates/agentai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -27,7 +27,7 @@ body = """
     {% endif %} \
     - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+### {{ group | split(pat=". ") | last | upper_first }}
     {% for commit in commits %}
         {%- if commit.scope -%}
             - *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}\


### PR DESCRIPTION



## 🤖 New release

* `agentai-macros`: 0.1.0 -> 0.1.5
* `agentai`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `agentai-macros`

<blockquote>

## [0.1.5](https://github.com/AdamStrojek/rust-agentai/compare/agentai-macros-v0.1.0...agentai-macros-v0.1.5) - 2025-07-19

### Miscellaneous
- Update lib.rs (by @AdamStrojek) - #27
- Move crates to separate folders (by @AdamStrojek) - #27

### Contributors

* @AdamStrojek
</blockquote>

## `agentai`

<blockquote>

## [0.1.5](https://github.com/AdamStrojek/rust-agentai/compare/agentai-v0.1.4...agentai-v0.1.5) - 2025-07-19

### New features
- ToolBox ([#18](https://github.com/AdamStrojek/rust-agentai/pull/18)) (by @AdamStrojek) - #18

### Miscellaneous
- Move crates to separate folders (by @AdamStrojek) - #27

### Contributors

* @AdamStrojek
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).