### PR TITLE
Release `agentai` v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.1.5](https://github.com/AdamStrojek/rust-agentai/compare/agentai-v0.1.4...agentai-v0.1.5) - 2025-07-20
+
+### New features
+- ToolBox ([#18](https://github.com/AdamStrojek/rust-agentai/pull/18)) (by @AdamStrojek) - #18
+
+### Miscellaneous
+- Update README.md (by @AdamStrojek) - #27
+- Update lib.rs (by @AdamStrojek) - #27
+- Update lib.rs (by @AdamStrojek) - #27
+- Move crates to separate folders (by @AdamStrojek) - #27
+- Update lib.rs (by @AdamStrojek) - #27
+
+### Contributors
+
+* @AdamStrojek
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [0.1.4](https://github.com/AdamStrojek/rust-agentai/compare/v0.1.3...v0.1.4) - 2025-05-21
 
 ### Changed

--- a/crates/agentai-macros/Cargo.toml
+++ b/crates/agentai-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai-macros"
-version = "0.1.0"
+version = "0.1.5"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"

--- a/crates/agentai/Cargo.toml
+++ b/crates/agentai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentai"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Adam Strojek <adam@strojek.info>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `agentai-macros`: 0.1.0 -> 0.1.5
* `agentai`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>


## `agentai`

<blockquote>

## [0.1.5](https://github.com/AdamStrojek/rust-agentai/compare/agentai-v0.1.4...agentai-v0.1.5) - 2025-07-20

### New features
- ToolBox ([#18](https://github.com/AdamStrojek/rust-agentai/pull/18)) (by @AdamStrojek) - #18

### Miscellaneous
- Update README.md (by @AdamStrojek) - #27
- Update lib.rs (by @AdamStrojek) - #27
- Update lib.rs (by @AdamStrojek) - #27
- Move crates to separate folders (by @AdamStrojek) - #27
- Update lib.rs (by @AdamStrojek) - #27

### Contributors

* @AdamStrojek
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).