### PR TITLE
Feature: mark Send and Sync on Toolbox trait

### DIFF
--- a/crates/agentai/src/tool/mod.rs
+++ b/crates/agentai/src/tool/mod.rs
@@ -69,7 +69,7 @@ pub use agentai_macros::toolbox;
 /// the [`#[toolbox]`](crate::tool::toolbox) attribute macro. This macro automatically
 /// generates the necessary `ToolBox` implementation for a struct based on its methods.
 #[async_trait::async_trait]
-pub trait ToolBox {
+pub trait ToolBox: Send + Sync + 'static {
     /// Returns a list of all `Tool` instances contained within this ToolBox.
     /// These definitions include the tool's name, description, and parameters,
     /// which are used by the language model to decide which tool to call.
@@ -161,7 +161,7 @@ impl ToolBoxSet {
     /// The order in which toolboxes are added is significant. When a tool call
     /// is made, the `ToolBoxSet` will search for the tool in the order the
     /// toolboxes were added.
-    pub fn add_tool(&mut self, toolbox: impl ToolBox + Send + Sync + 'static) {
+    pub fn add_tool(&mut self, toolbox: impl ToolBox) {
         self.toolboxes.push(Box::new(toolbox));
     }
 }


### PR DESCRIPTION
First of all, thank you for building this crate. It's coming is use for some hobby project I'm working on.

This small change marks the Toolbox trait safe for sending and sharing between threads.

I ran into this when trying to use an Agent in an [axum](https://docs.rs/axum/latest/axum/) API, which would not compile due to these markers missing.

Noticed that this was also already included in PR #24, but I got the feeling there's too many open remarks on there for it to get merged.